### PR TITLE
 [EPMDEDP-16736]: chore: Update EBS CSI Driver IAM policy

### DIFF
--- a/eks/irsa.tf
+++ b/eks/irsa.tf
@@ -11,7 +11,7 @@ module "aws_ebs_csi_driver_irsa" {
   permissions_boundary = var.role_permissions_boundary_arn
   use_name_prefix      = false
   policies = {
-    AmazonEBSCSIDriverPolicy = "arn:aws:iam::aws:policy/service-role/AmazonEBSCSIDriverPolicy"
+    AmazonEBSCSIDriverPolicy = "arn:aws:iam::aws:policy/AmazonEBSCSIDriverPolicyV2"
   }
 
   oidc_providers = {


### PR DESCRIPTION
Update EBS CSI Driver IAM policy to AmazonEBSCSIDriverPolicyV2

  - Migrate from deprecated AmazonEBSCSIDriverPolicy (v1) to the newer  AmazonEBSCSIDriverPolicyV2 managed policy
  - V2 is AWS's recommended least-privilege policy for EBS CSI Driver