### PR TITLE
EPMDEDP-17136: feat: support Envoy Gateway routing on the ingress ALB

### DIFF
--- a/eks/alb.tf
+++ b/eks/alb.tf
@@ -30,22 +30,61 @@ module "alb" {
       forward = {
         target_group_key = "http-instance"
       }
+
+      # nginx-ingress -> Envoy Gateway migration: route the configured host header(s)
+      # to the Envoy Gateway target group (envoy-instance); every other host keeps
+      # hitting the default forward action (http-instance -> nginx-ingress). Enabled
+      # per the envoy_gateway_route_enabled flag (default off).
+      rules = var.envoy_gateway_route_enabled ? {
+        envoy = {
+          priority = 10
+          actions = [{
+            type             = "forward"
+            target_group_key = "envoy-instance"
+          }]
+          conditions = [{
+            host_header = {
+              values = var.envoy_gateway_route_hosts
+            }
+          }]
+        }
+      } : {}
     }
   }
 
-  target_groups = {
-    http-instance = {
-      name                 = "${var.platform_name}-infra-alb-http"
-      port                 = 32080
-      protocol             = "HTTP"
-      deregistration_delay = 20
-      create_attachment    = false
+  target_groups = merge(
+    {
+      http-instance = {
+        name                 = "${var.platform_name}-infra-alb-http"
+        port                 = 32080
+        protocol             = "HTTP"
+        deregistration_delay = 20
+        create_attachment    = false
 
-      health_check = {
-        matcher = 404
+        health_check = {
+          matcher = 404
+        }
       }
-    }
-  }
+    },
+    # nginx-ingress -> Envoy Gateway migration: extra target group pointing at the
+    # Envoy Gateway data plane NodePort. Added only when the route is enabled, so the
+    # default setup is unchanged. No new load balancer is created.
+    var.envoy_gateway_route_enabled ? {
+      envoy-instance = {
+        # Envoy Gateway data plane NodePort (envoy-gateway-resources EnvoyProxy
+        # "http-proxy"). ALB terminates TLS on :443 and forwards plain HTTP here.
+        name                 = "${var.platform_name}-infra-alb-envoy"
+        port                 = 32180
+        protocol             = "HTTP"
+        deregistration_delay = 20
+        create_attachment    = false
+
+        health_check = {
+          matcher = "200,404"
+        }
+      }
+    } : {}
+  )
   idle_timeout = 500
   access_logs = {
     bucket = "prod-s3-elb-logs-eu-central-1"

--- a/eks/example.tfvars
+++ b/eks/example.tfvars
@@ -50,3 +50,9 @@ cluster_identity_providers = {
     groups_claim = "groups"
   }
 }
+
+# -- nginx-ingress -> Envoy Gateway migration ---------------------------------
+# Route selected host(s) through Envoy Gateway via an extra target group + HTTPS
+# listener rule on the existing ingress ALB (no new load balancer). Default off.
+# envoy_gateway_route_enabled = true
+# envoy_gateway_route_hosts   = ["<COMPONENT>-<NAMESPACE>.<PLATFORM_NAME>.<PLATFORM_DNS>"]

--- a/eks/main.tf
+++ b/eks/main.tf
@@ -8,6 +8,20 @@ resource "aws_autoscaling_attachment" "self_managed_asg_tg" {
   lb_target_group_arn    = module.alb.target_groups["http-instance"].arn
 }
 
+# nginx-ingress -> Envoy Gateway migration: attach the node ASGs to the Envoy
+# target group so the Envoy data-plane NodePort is registered as a target. Created
+# only when envoy_gateway_route_enabled = true (the envoy-instance target group
+# exists then); otherwise for_each is empty and nothing is created.
+resource "aws_autoscaling_attachment" "self_managed_asg_tg_envoy" {
+  for_each = var.envoy_gateway_route_enabled ? {
+    spot      = module.eks.self_managed_node_groups_autoscaling_group_names[0]
+    on_demand = module.eks.self_managed_node_groups_autoscaling_group_names[1]
+  } : {}
+
+  autoscaling_group_name = each.value
+  lb_target_group_arn    = module.alb.target_groups["envoy-instance"].arn
+}
+
 module "key_pair" {
   source  = "terraform-aws-modules/key-pair/aws"
   version = "2.1.0"
@@ -217,7 +231,7 @@ module "eks" {
       resolve_conflicts        = "OVERWRITE"
       service_account_role_arn = module.vpc_cni_irsa.arn
     },
-    eks-pod-identity-agent  = {
+    eks-pod-identity-agent = {
       addon_version               = "v1.3.10-eksbuild.2"
       resolve_conflicts_on_update = "OVERWRITE"
       resolve_conflicts_on_create = "OVERWRITE"

--- a/eks/template.tfvars
+++ b/eks/template.tfvars
@@ -43,3 +43,9 @@ tags = ""
 
 # OIDC Identity provider
 cluster_identity_providers = {}
+
+# -- nginx-ingress -> Envoy Gateway migration ---------------------------------
+# Route selected host(s) through Envoy Gateway via an extra target group + HTTPS
+# listener rule on the existing ingress ALB (no new load balancer). Default off.
+# envoy_gateway_route_enabled = true
+# envoy_gateway_route_hosts   = ["<COMPONENT>-<NAMESPACE>.<PLATFORM_NAME>.<PLATFORM_DNS>"]

--- a/eks/variables.tf
+++ b/eks/variables.tf
@@ -197,3 +197,16 @@ variable "admin_role_prefix" {
   type        = string
   default     = "AWSReservedSSO_AdminUser"
 }
+
+# nginx-ingress -> Envoy Gateway migration
+variable "envoy_gateway_route_enabled" {
+  description = "Route selected host header(s) through the Envoy Gateway data plane by adding an extra target group + HTTPS listener rule on the existing ingress ALB. Disabled by default; enable during the nginx-ingress -> Envoy Gateway migration. No new load balancer is created."
+  type        = bool
+  default     = false
+}
+
+variable "envoy_gateway_route_hosts" {
+  description = "Host header value(s) routed to Envoy Gateway when envoy_gateway_route_enabled is true. ALB wildcard globs are allowed (e.g. \"<COMPONENT>-<NAMESPACE>.<PLATFORM_NAME>.<PLATFORM_DNS>\")."
+  type        = list(string)
+  default     = []
+}


### PR DESCRIPTION
## What

Add the capability to route selected host header(s) through an **Envoy Gateway** data plane via an extra target group + an HTTPS listener rule on the **existing** ingress ALB — behind a new feature flag, **disabled by default**. No new load balancer.

Adapted to this module's ALB v9 (map-based `listeners` / `target_groups`):

- `eks/alb.tf` — when `envoy_gateway_route_enabled` is set:
  - add a conditional `envoy-instance` target group (Envoy data-plane NodePort `32180`, HTTP) to the `target_groups` map;
  - add a `rules` entry on the `https` listener forwarding the configured host(s) to it (`target_group_key = "envoy-instance"`). The default `:443` forward action (→ `http-instance`, nginx-ingress) is unchanged.
- `eks/main.tf` — a conditional `aws_autoscaling_attachment` that registers the self-managed node ASGs on the Envoy target group (mirrors the existing `http-instance` attachment).
- `eks/variables.tf` — new `envoy_gateway_route_enabled` (bool, default `false`) and `envoy_gateway_route_hosts` (list(string), default `[]`).
- `eks/template.tfvars`, `eks/example.tfvars` — documented (commented) usage example.

## Why

Aligns the reference (upstream) Terraform module for the nginx-ingress → Envoy Gateway migration (ticket AC: *"Upstream Terraform code is aligned"*). Consumers of this module can opt a host onto Envoy Gateway, on the existing ALB, without provisioning a separate load balancer or editing module internals — just two tfvars:

```hcl
envoy_gateway_route_enabled = true
envoy_gateway_route_hosts   = ["<host>"]
```

## Impact

- **Default off → `terraform plan` is a no-op for every existing consumer.** With the flag unset, `merge(...)` collapses to the current `target_groups`, the listener `rules` map is empty, and the extra attachment's `for_each` is empty — nothing is created.
- Purely additive: the existing `http-instance` target group, the `:443` default forward action, and the node attachment are untouched.
- No new load balancer (reuses the existing `${platform_name}-ingress-alb`).

## Related

Same ticket **EPMDEDP-17136**. The live counterpart (already merged) applies the equivalent routing on the `eks-sandbox` cluster and enables it for the `krci-portal` host:
- `platform-epmd-sandbox` — ALB target group + listener rule, enabled in tfvars;
- `KubeRocketCI/krci-portal` — optional HTTPRoute support in the chart;
- `edp-delivery-gitops` — per-env enablement for `vpi/dev`.

## Note

`terraform fmt` also normalized one pre-existing unrelated alignment in `eks/main.tf` (`eks-pod-identity-agent`) — included because the `terraform_fmt` hook reformats the whole changed file.

Jira: EPMDEDP-17136