### PR TITLE
EPMDEDP-17136: feat: add Envoy Gateway default-action toggle for the …

### DIFF
--- a/eks/alb.tf
+++ b/eks/alb.tf
@@ -27,25 +27,50 @@ module "alb" {
       ssl_policy      = var.ssl_policy
       certificate_arn = module.acm.acm_certificate_arn
 
+      # nginx-ingress -> Envoy Gateway migration: the default :443 action forwards to the
+      # Envoy data-plane target group only when it exists (envoy_gateway_enabled) AND the
+      # default is flipped (platform_default_gateway = "envoy"); otherwise it keeps hitting
+      # nginx-ingress. See eks/variables.tf for the two-step relationship.
       forward = {
-        target_group_key = "http-instance"
+        target_group_key = (var.envoy_gateway_enabled && var.platform_default_gateway == "envoy") ? "envoy-instance" : "http-instance"
       }
     }
   }
 
-  target_groups = {
-    http-instance = {
-      name                 = "${var.platform_name}-infra-alb-http"
-      port                 = 32080
-      protocol             = "HTTP"
-      deregistration_delay = 20
-      create_attachment    = false
+  target_groups = merge(
+    {
+      http-instance = {
+        name                 = "${var.platform_name}-infra-alb-http"
+        port                 = 32080
+        protocol             = "HTTP"
+        deregistration_delay = 20
+        create_attachment    = false
 
-      health_check = {
-        matcher = 404
+        health_check = {
+          matcher = 404
+        }
       }
-    }
-  }
+    },
+    # nginx-ingress -> Envoy Gateway migration: extra target group pointing at the Envoy
+    # Gateway data-plane NodePort. Created only when envoy_gateway_enabled = true; the ALB
+    # default action forwards here once platform_default_gateway = "envoy". No new load
+    # balancer is created.
+    var.envoy_gateway_enabled ? {
+      envoy-instance = {
+        # Envoy Gateway data plane NodePort (envoy-gateway-resources EnvoyProxy). The ALB
+        # terminates TLS on :443 and forwards plain HTTP here.
+        name                 = "${var.platform_name}-infra-alb-envoy"
+        port                 = 32180
+        protocol             = "HTTP"
+        deregistration_delay = 20
+        create_attachment    = false
+
+        health_check = {
+          matcher = "200,404"
+        }
+      }
+    } : {}
+  )
   idle_timeout = 500
   access_logs = {
     bucket = "prod-s3-elb-logs-eu-central-1"

--- a/eks/example.tfvars
+++ b/eks/example.tfvars
@@ -50,3 +50,10 @@ cluster_identity_providers = {
     groups_claim = "groups"
   }
 }
+
+# -- nginx-ingress -> Envoy Gateway migration (optional, default off) ----------
+# Two related switches for a zero-downtime cutover; see eks/variables.tf.
+# Step 1 - provision the Envoy Gateway data-plane target group (no traffic yet):
+# envoy_gateway_enabled = true
+# Step 2 - once that target group is healthy, flip the ALB default action to Envoy:
+# platform_default_gateway = "envoy"

--- a/eks/main.tf
+++ b/eks/main.tf
@@ -8,6 +8,20 @@ resource "aws_autoscaling_attachment" "self_managed_asg_tg" {
   lb_target_group_arn    = module.alb.target_groups["http-instance"].arn
 }
 
+# nginx-ingress -> Envoy Gateway migration: register the node ASGs on the Envoy target
+# group so its NodePort becomes a healthy target. Created only when envoy_gateway_enabled
+# is true (the envoy-instance target group exists then); otherwise for_each is empty and
+# nothing is created. Pairs with platform_default_gateway — see eks/variables.tf.
+resource "aws_autoscaling_attachment" "self_managed_asg_tg_envoy" {
+  for_each = var.envoy_gateway_enabled ? {
+    spot      = module.eks.self_managed_node_groups_autoscaling_group_names[0]
+    on_demand = module.eks.self_managed_node_groups_autoscaling_group_names[1]
+  } : {}
+
+  autoscaling_group_name = each.value
+  lb_target_group_arn    = module.alb.target_groups["envoy-instance"].arn
+}
+
 module "key_pair" {
   source  = "terraform-aws-modules/key-pair/aws"
   version = "2.1.0"
@@ -217,7 +231,7 @@ module "eks" {
       resolve_conflicts        = "OVERWRITE"
       service_account_role_arn = module.vpc_cni_irsa.arn
     },
-    eks-pod-identity-agent  = {
+    eks-pod-identity-agent = {
       addon_version               = "v1.3.10-eksbuild.2"
       resolve_conflicts_on_update = "OVERWRITE"
       resolve_conflicts_on_create = "OVERWRITE"

--- a/eks/template.tfvars
+++ b/eks/template.tfvars
@@ -43,3 +43,10 @@ tags = ""
 
 # OIDC Identity provider
 cluster_identity_providers = {}
+
+# -- nginx-ingress -> Envoy Gateway migration (optional, default off) ----------
+# Two related switches for a zero-downtime cutover; see eks/variables.tf.
+# Step 1 - provision the Envoy Gateway data-plane target group (no traffic yet):
+# envoy_gateway_enabled = true
+# Step 2 - once that target group is healthy, flip the ALB default action to Envoy:
+# platform_default_gateway = "envoy"

--- a/eks/variables.tf
+++ b/eks/variables.tf
@@ -197,3 +197,32 @@ variable "admin_role_prefix" {
   type        = string
   default     = "AWSReservedSSO_AdminUser"
 }
+
+# nginx-ingress -> Envoy Gateway migration -------------------------------------
+# The two variables below are a related pair and are kept together on purpose.
+# Apply them in two steps for a zero-downtime cutover:
+#   1. envoy_gateway_enabled = true       provisions the Envoy Gateway data-plane
+#      target group on the existing ingress ALB and registers the node ASGs on it.
+#      Nothing is routed to it yet, so it is safe to apply alone; wait for the target
+#      group to become healthy.
+#   2. platform_default_gateway = "envoy" flips the ALB default :443 action onto that
+#      target group. It only takes effect once envoy_gateway_enabled is true. The
+#      in-cluster nginx-fallback catch-all HTTPRoute then sends any host that still
+#      lacks its own HTTPRoute back to nginx-ingress.
+# To roll back, reverse the order: set platform_default_gateway = "nginx" first.
+variable "envoy_gateway_enabled" {
+  description = "Provision the Envoy Gateway data-plane target group (NodePort 32180) on the existing ingress ALB and register the node ASGs on it. No new load balancer is created and no traffic reaches it until platform_default_gateway = \"envoy\". Prerequisite for platform_default_gateway: enable this first and wait for the target group to become healthy before flipping the default action."
+  type        = bool
+  default     = false
+}
+
+variable "platform_default_gateway" {
+  description = "Which data plane the ingress ALB default :443 action forwards to. \"nginx\" (default) keeps today's behaviour; \"envoy\" flips the default onto the Envoy Gateway data-plane target group so every host hits Envoy first, and any host that only has an Ingress (no HTTPRoute) falls through to nginx-ingress via the in-cluster nginx-fallback catch-all HTTPRoute (ingress-nginx add-on). Only takes effect when envoy_gateway_enabled = true, whose target group it forwards to; set that first and confirm the target group is healthy before setting \"envoy\"."
+  type        = string
+  default     = "nginx"
+
+  validation {
+    condition     = contains(["nginx", "envoy"], var.platform_default_gateway)
+    error_message = "platform_default_gateway must be either \"nginx\" or \"envoy\"."
+  }
+}


### PR DESCRIPTION
## Description

Adds two related, opt-in variables that let the ingress ALB hand its **default `:443`
traffic** to **Envoy Gateway** instead of nginx-ingress, as part of migrating the platform
edge from nginx-ingress to Envoy Gateway.

The change is deliberately split into **two knobs** so the cutover is a **two-step,
zero-downtime** operation rather than a single risky flip:

**1. `envoy_gateway_enabled` (bool, default `false`) — provision the data plane.**
When `true`, it creates an `envoy-instance` ALB target group pointing at the Envoy Gateway
NodePort (`32180`) and attaches the node Auto Scaling Groups to it (`aws_autoscaling_attachment`
for the spot and on-demand ASGs), so the nodes register as targets and the group can become
healthy. **Nothing is routed to it yet** — this step only builds and warms up the target
group. The default ALB action is untouched and still forwards to nginx-ingress.

**2. `platform_default_gateway` (string `nginx` | `envoy`, default `nginx`) — flip the edge.**
When set to `envoy`, the ALB's default `:443` action forwards to the `envoy-instance` target
group instead of the nginx target group. From that point the ALB delivers all otherwise-
unmatched host traffic into Envoy Gateway.

Doing it in two applies means you flip the default action **only after** the Envoy target
group is already healthy, which avoids the ~30s window of `503`s you'd get by pointing the
edge at a target group that is still running its first health checks. Rollback is the reverse
order: set `platform_default_gateway = "nginx"` first, then (optionally) tear the target group
back down.

**Dependency on the in-cluster catch-all.** Flipping the edge to Envoy is only safe because of
the companion **`nginx-fallback` catch-all `HTTPRoute`** (see `edp-cluster-add-ons`,
`EPMDEDP-17136`). Once Envoy Gateway is the edge, only hosts with an explicit `HTTPRoute` are
served by Envoy directly; the catch-all — a hostname-less, lowest-precedence route — forwards
everything else back to nginx-ingress. So the full path for a not-yet-migrated host becomes
`ALB → Envoy Gateway → nginx-fallback → nginx-ingress → Ingress`, and hosts can be moved onto
native Envoy routes one at a time. **The catch-all must be deployed before
`platform_default_gateway = "envoy"` is applied**, otherwise unmatched hosts would have no
backend.

**Safety invariant.** The default listener action's `target_group_key` is guarded so it can
only resolve to `envoy-instance` when `envoy_gateway_enabled` is also `true`
(`envoy_gateway_enabled && platform_default_gateway == "envoy" ? "envoy-instance" :
"http-instance"`), and the `envoy-instance` target group is created in the same condition.
This guarantees the default action never references a target group that doesn't exist in the
map, even if someone sets `platform_default_gateway = "envoy"` without enabling the data plane.

Both variables default to today's behavior, so this is a no-op for existing clusters until
they explicitly opt in. The two variables are kept adjacent in `variables.tf` with a shared
comment explaining that they are an interrelated pair and how to sequence them.

Tracking: EPMDEDP-17136 (nginx-ingress → Envoy Gateway migration).

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (non-breaking change which improves an existing feature or documentation)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## How Has This Been Tested?

The repository pins Terraform `1.5.7`, so the full `plan`/`validate` runs in Atlantis.
Locally the change was verified as follows:

```bash
# 1. terraform fmt is clean on the edited files
terraform fmt -check -diff eks

# 2. Behavior matrix — the toggle/merge/attachment logic was replicated in a standalone
#    project (no providers, no version pin) and evaluated for every combination:
```

| `envoy_gateway_enabled` | `platform_default_gateway` | target groups created | default `:443` forwards to | envoy ASG attached |
|:---:|:---:|---|:---:|:---:|
| false | nginx | `http-instance` | `http-instance` | no |
| true  | nginx | `http-instance`, `envoy-instance` | `http-instance` | yes |
| false | envoy | `http-instance` | `http-instance` (guard) | no |
| true  | envoy | `http-instance`, `envoy-instance` | `envoy-instance` | yes |

```text
# 3. Safety invariant — across all four cases the default action's target_group_key is always
#    a key that exists in the target_groups map (never dangling). Asserted true.

# 4. Variable validation:
#      platform_default_gateway = "nginx"  -> accepted
#      platform_default_gateway = "envoy"  -> accepted
#      platform_default_gateway = "bogus"  -> rejected ("must be either \"nginx\" or \"envoy\".")
```

- Row 1 (`false` / `nginx`) is identical to current behavior; the Envoy target group is not
  even created.
- Row 2 is safe step 1: target group provisioned and registered, default action untouched.
- Row 3 is the guard: the flip is ignored because the target group does not exist.
- Row 4 is the flip.

## Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Pull Request contains one commit. I squash my commits.

## Screenshots (if appropriate):

N/A

## Additional context

- `example.tfvars` and `template.tfvars` document the two-step migration with commented
  examples.
- Depends operationally on the in-cluster `nginx-fallback` catch-all `HTTPRoute`
  (`edp-cluster-add-ons`, `EPMDEDP-17136`), which must be present before
  `platform_default_gateway = "envoy"` is applied.
- Uses the existing `terraform-aws-modules/alb/aws` interface (`listeners`, `target_groups`,
  `forward.target_group_key`); no module version change.